### PR TITLE
Updates eslint config for broader file matching

### DIFF
--- a/ClientApp/eslint.config.js
+++ b/ClientApp/eslint.config.js
@@ -17,9 +17,9 @@ const ignore = [
   'OidcTrustedDomains.js',
 ];
 
-const files = ['src/*.js', 'src/*.jsx', 'src/*.ts', 'src/*.tsx'];
+const files = ['src/**/*.{js,jsx,ts,tsx}'];
 
-const testFiles = ['tests/*.js', 'tests/*.ts', 'src/**/__tests__/*.{js,jsx,ts,tsx}'];
+const testFiles = ['tests/**/*.{js,jsx,ts,tsx}', 'src/**/__tests__/*.{js,jsx,ts,tsx}'];
 
 export default [
   {


### PR DESCRIPTION
Updates the eslint configuration to use glob patterns for matching files in the src and tests directories. This ensures that all relevant files are linted, regardless of their subdirectory.
